### PR TITLE
[FEAT] News와 Comment 모델 추가 (ResponseDTO & Entity)

### DIFF
--- a/NewsFit/NewsFit/Model/Comment.swift
+++ b/NewsFit/NewsFit/Model/Comment.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct Comment: Identifiable {
+  let id: Int
+  let content: String
+  let author: String
+  let createdAt: Date
+}

--- a/NewsFit/NewsFit/Model/DTO/CommentResponseDTO.swift
+++ b/NewsFit/NewsFit/Model/DTO/CommentResponseDTO.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct CommentResponseDTO: Decodable {
+  let commentId: Int
+  let content: String
+  let nickName: String
+  let createdDate: Date
+  let isDeleted: Bool
+}

--- a/NewsFit/NewsFit/Model/DTO/NewsResponseDTO.swift
+++ b/NewsFit/NewsFit/Model/DTO/NewsResponseDTO.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct NewsResponseDTO: Decodable {
+  let createdDate: Date
+  let lastModifiedDate: Date
+  let isDeleted: Bool
+  let articleID: Int
+  let title: String
+  let content: String
+  let press: String
+  let category: String
+  let comments: [CommentResponseDTO]
+  
+  enum CodingKeys: String, CodingKey {
+    case createdDate
+    case lastModifiedDate
+    case isDeleted
+    case articleID = "article_id"
+    case title
+    case content
+    case press
+    case category
+    case comments
+  }
+}

--- a/NewsFit/NewsFit/Model/News.swift
+++ b/NewsFit/NewsFit/Model/News.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-struct News {
+struct News: Identifiable {
+  let id: Int
   let title: String
   let content: String
   let createdAt: Date

--- a/NewsFit/NewsFit/Model/News.swift
+++ b/NewsFit/NewsFit/Model/News.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct News {
+  let title: String
+  let content: String
+  let createdAt: Date
+  let press: String
+  let category: String
+  let comments: [Comment]
+}


### PR DESCRIPTION
### 배경
일단 표시할 데이터가 필요하여 만들었습니다.

### 변경사항
- [x]  DTO 설계하기
    - [x]  response
- [x]  Entity설계하기
    - [x]  내가 사용할 것을 구분

## 구현 이유

### List랑 Single이랑 다름

일단, News에 있어서는 Request요청은 없을 것이라 생각했습니다.

(유저가 뭐 삭제하라고 하는 것도 아니고,,, 수정 뭐 그런 것도 없겠죠?)

response의 경우 API명세에서 List / Single로 fetch했을 때가 각각 달랐습니다.

따라서, List에 있는 데이터가 더 뷰와 맞다고 생각해서 이를 선택했습니다.

### DTO/Entity

News에는 Comment데이터도 포함되더라구요? 그래서 이것도 같이 만들어주었습니다.

ResponseDTO의 경우 돌려주는 데이터 전부를 그냥 매핑했습니다.

Entity의 경우 뷰에서 요구되는 것을 위주로 가져왔습니다.

News

- id
- 제목
- 본문
- 카테고리
- 생성일
- 댓글
- 신문사

Comment

- id
- 본문
- 작성자
- 생성일