### PR TITLE
[FEAT] 홈 네비게이션 구현 및 연결

### DIFF
--- a/NewsFit/NewsFit/AppEssential/SceneDelegate.swift
+++ b/NewsFit/NewsFit/AppEssential/SceneDelegate.swift
@@ -16,38 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let scene = (scene as? UIWindowScene) else { return }
     
     window = UIWindow(windowScene: scene)
-    let vc = CustomNavigationController(rootViewController: NewsFitHomeViewController())
+    let vc = NewsFitHomeNavigationController(rootViewController: NewsFitHomeViewController())
     window?.rootViewController = vc
     window?.makeKeyAndVisible()
-  }
-}
-
-fileprivate final class CustomNavigationController: UINavigationController {
-  let logoImageView: UIImageView = {
-    let imageView = UIImageView()
-    imageView.image = .newsFitLogo
-    imageView.contentMode = .scaleAspectFit
-    return imageView
-  }()
-  
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    
-    configure()
-  }
-  
-  func configure() {
-    navigationBar.addSubview(logoImageView)
-    logoImageView.snp.makeConstraints { make in
-      make.leading.equalToSuperview()
-      make.centerY.equalToSuperview()
-      make.height.equalToSuperview().offset(-20)
-    }
-    
-    let appearance = UINavigationBarAppearance()
-    appearance.backgroundColor = .white
-    
-    navigationBar.standardAppearance = appearance
-    navigationBar.scrollEdgeAppearance = appearance
   }
 }

--- a/NewsFit/NewsFit/AppEssential/SceneDelegate.swift
+++ b/NewsFit/NewsFit/AppEssential/SceneDelegate.swift
@@ -16,10 +16,38 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let scene = (scene as? UIWindowScene) else { return }
     
     window = UIWindow(windowScene: scene)
-    let vc = NewsFitHomeViewController()
-    vc.view.backgroundColor = .blue
+    let vc = CustomNavigationController(rootViewController: NewsFitHomeViewController())
     window?.rootViewController = vc
     window?.makeKeyAndVisible()
   }
 }
 
+fileprivate final class CustomNavigationController: UINavigationController {
+  let logoImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.image = .newsFitLogo
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    configure()
+  }
+  
+  func configure() {
+    navigationBar.addSubview(logoImageView)
+    logoImageView.snp.makeConstraints { make in
+      make.leading.equalToSuperview()
+      make.centerY.equalToSuperview()
+      make.height.equalToSuperview().offset(-20)
+    }
+    
+    let appearance = UINavigationBarAppearance()
+    appearance.backgroundColor = .white
+    
+    navigationBar.standardAppearance = appearance
+    navigationBar.scrollEdgeAppearance = appearance
+  }
+}

--- a/NewsFit/NewsFit/View/NewsFitHomeNavigationController.swift
+++ b/NewsFit/NewsFit/View/NewsFitHomeNavigationController.swift
@@ -1,0 +1,35 @@
+import UIKit
+
+final class NewsFitHomeNavigationController: UINavigationController {
+  //MARK: - Property
+  let logoImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.image = .newsFitLogo
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+  
+  //MARK: - LifeCycle
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    configure()
+  }
+  
+  //MARK: - Helper
+  private func configure() {
+    navigationBar.addSubview(logoImageView)
+    logoImageView.snp.makeConstraints { make in
+      make.leading.equalToSuperview()
+      make.centerY.equalToSuperview()
+      make.height.equalToSuperview().offset(-20)
+    }
+    
+    let appearance = UINavigationBarAppearance()
+    appearance.configureWithTransparentBackground()
+    appearance.backgroundColor = .white
+    
+    navigationBar.standardAppearance = appearance
+    navigationBar.scrollEdgeAppearance = appearance
+  }
+}

--- a/NewsFit/NewsFit/View/NewsFitHomeViewController.swift
+++ b/NewsFit/NewsFit/View/NewsFitHomeViewController.swift
@@ -16,6 +16,7 @@ final class NewsFitHomeViewController: UIViewController {
     
     setup()
     configureHirachy()
+//    configureNavigationController()
   }
   
   //MARK: - Helper
@@ -50,7 +51,7 @@ final class NewsFitHomeViewController: UIViewController {
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .continuous
         section.interGroupSpacing = 8
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 20, bottom: 0, trailing: 20)
         return section
       } else if sectionIndex == 1 {
         group.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
@@ -89,6 +90,14 @@ final class NewsFitHomeViewController: UIViewController {
     collectionView.snp.makeConstraints { make in
       make.edges.equalToSuperview()
     }
+  }
+  private func configureNavigationController() {
+    let appearance = UINavigationBarAppearance()
+    appearance.backgroundImage = .newsFitLogo
+    appearance.backgroundImageContentMode = .scaleAspectFit
+//    appearance.backgroundColor = .nfBorderPurple
+    navigationController?.navigationBar.standardAppearance = appearance
+    navigationController?.navigationBar.scrollEdgeAppearance = appearance
   }
 }
 

--- a/NewsFit/NewsFit/View/NewsFitHomeViewController.swift
+++ b/NewsFit/NewsFit/View/NewsFitHomeViewController.swift
@@ -16,7 +16,6 @@ final class NewsFitHomeViewController: UIViewController {
     
     setup()
     configureHirachy()
-//    configureNavigationController()
   }
   
   //MARK: - Helper
@@ -90,14 +89,6 @@ final class NewsFitHomeViewController: UIViewController {
     collectionView.snp.makeConstraints { make in
       make.edges.equalToSuperview()
     }
-  }
-  private func configureNavigationController() {
-    let appearance = UINavigationBarAppearance()
-    appearance.backgroundImage = .newsFitLogo
-    appearance.backgroundImageContentMode = .scaleAspectFit
-//    appearance.backgroundColor = .nfBorderPurple
-    navigationController?.navigationBar.standardAppearance = appearance
-    navigationController?.navigationBar.scrollEdgeAppearance = appearance
   }
 }
 


### PR DESCRIPTION
## 변경 사항
- [x]  네비이션추가
- [x]  네비게이션에 로고 추가
- [x]  구분선 없애기

## 테스트 방법
실행하면 됨!

## 리뷰 노트
일단 네비게이션은 어디에 위치해야할까?

홈을 위한 전용 네비게이션 바니까 홈 안에 위치하는 것이 좋겠다.

만들다가 생각이 든게, 이것은 과연 네비게이션이 맞나?라는 생각

스크롤을 어떻게 처리할지도 고민이다.

1. 전체 페이지가 함께 움직임
2. NewsFit로고와 알림 영역은 고정됨
3. NewFit로고와 알림 영역 및 카테고리 선택 영역은 고정됨

이렇게 3가지정도 생각할 수 있을 것같은데…

일단 어플들에서는 2번형식이 많아보여서 이것을 쓰기로 했다.

## 스크린샷

https://github.com/user-attachments/assets/566b3372-a14a-4392-96b4-f05b50e5826c
