### PR TITLE
[FEAT] HeadLine 뷰모델 만들기

### DIFF
--- a/NewsFit/NewsFit/View/HeadLineNews/HeadLineNewsCell.swift
+++ b/NewsFit/NewsFit/View/HeadLineNews/HeadLineNewsCell.swift
@@ -61,7 +61,6 @@ struct HeadLineNewsCell: View {
       press: "한겨레",
       body: "부상자 361명, 15만5천명 대피",
       imageURL: nil,
-      isFocused: false,
       createdDate: .now
     )
   )

--- a/NewsFit/NewsFit/View/HeadLineNews/HeadLineNewsCell.swift
+++ b/NewsFit/NewsFit/View/HeadLineNews/HeadLineNewsCell.swift
@@ -1,43 +1,68 @@
 import SwiftUI
 
 struct HeadLineNewsCell: View {
+  //MARK: - Properties
+  @State var viewModel: HeadLineNewsPresentable
+  
+  //MARK: - View
   var body: some View {
-    VStack {
-      Spacer()
+    ZStack {
+      Image(.newsFitLogo)
+        .resizable()
+        .scaledToFit()
       VStack(alignment: .leading) {
-        Text("\"최악의 기후재앙\"...브라질 남부 폭우에 사망.실종 220명 넘어서")
-          .font(.headline)
-          .foregroundStyle(.white)
-          .padding(.bottom)
-        Text("부상자 361명, 15만5천명 대피")
-          .foregroundStyle(.white)
-      }
-      Spacer()
-      HStack {
-        Text("한겨레")
-          .foregroundStyle(.white)
         Spacer()
-        Text("2024.05.28")
-          .foregroundStyle(.white)
+        centerTitleAndBody(viewModel)
+        Spacer()
+        bottomDescription(viewModel)
       }
-    }.padding()
-      .background(
-        Image(.newsFitLogo)
-          .resizable()
-          .scaledToFit()
-      )
+      .padding()
       .background(
         Gradient(
           colors: [
             .black.opacity(0.1),
             .black.opacity(0.6)
           ]
-        ).blendMode(.multiply)
+        )
       )
       .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+  }
+  
+  //MARK: - Helper
+  @ViewBuilder
+  private func centerTitleAndBody(_ viewModel: HeadLineNewsPresentable) -> some View {
+    VStack(alignment: .leading) {
+      Text(viewModel.title)
+        .font(.headline)
+        .foregroundStyle(.white)
+        .padding(.bottom)
+      Text(viewModel.body)
+        .foregroundStyle(.white)
+    }
+  }
+  @ViewBuilder
+  private func bottomDescription(_ viewModel: HeadLineNewsPresentable) -> some View {
+    HStack {
+      Text(viewModel.press)
+        .foregroundStyle(.white)
+      Spacer()
+      Text(viewModel.date)
+        .foregroundStyle(.white)
+    }
   }
 }
 
+//MARK: - Preview
 #Preview {
-  HeadLineNewsCell()
+  HeadLineNewsCell(
+    viewModel: HeadLineNewsViewModel(
+      title: "dma",
+      press: "한겨레",
+      body: "부상자 361명, 15만5천명 대피",
+      imageURL: nil,
+      isFocused: false,
+      createdDate: .now
+    )
+  )
 }

--- a/NewsFit/NewsFit/View/HeadLineNews/HeadLineNewsViewModel.swift
+++ b/NewsFit/NewsFit/View/HeadLineNews/HeadLineNewsViewModel.swift
@@ -15,11 +15,7 @@ protocol PressImagePresentable {
   var pressImageURL: URL? { get }
 }
 
-protocol Focusable {
-  var isFocused: Bool { get }
-}
-
-typealias HeadLineNewsPresentable = NewsPresentable & NewsDescriptionPresentable & Focusable
+typealias HeadLineNewsPresentable = NewsPresentable & NewsDescriptionPresentable
 
 struct HeadLineNewsViewModel: HeadLineNewsPresentable {
   //MARK: - Properties
@@ -32,15 +28,17 @@ struct HeadLineNewsViewModel: HeadLineNewsPresentable {
   }
   let body: String
   let imageURL: URL?
-  var isFocused: Bool
   private let createdDate: Date
   
-  init(title: String, press: String, body: String, imageURL: URL?, isFocused: Bool, createdDate: Date) {
+  //MARK: - Initializers
+  init(news: News) {
+    self.init(title: news.title, press: news.press, body: news.content, imageURL: nil, createdDate: news.createdAt)
+  }
+  init(title: String, press: String, body: String, imageURL: URL?, createdDate: Date) {
     self.title = title
     self.press = press
     self.body = body
     self.imageURL = imageURL
-    self.isFocused = isFocused
     self.createdDate = createdDate
   }
 }

--- a/NewsFit/NewsFit/View/HeadLineNews/HeadLineNewsViewModel.swift
+++ b/NewsFit/NewsFit/View/HeadLineNews/HeadLineNewsViewModel.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+protocol NewsPresentable {
+  var title: String { get }
+  var press: String { get }
+  var date: String { get }
+  var imageURL: URL? { get }
+}
+
+protocol NewsDescriptionPresentable {
+  var body: String { get }
+}
+
+protocol PressImagePresentable {
+  var pressImageURL: URL? { get }
+}
+
+protocol Focusable {
+  var isFocused: Bool { get }
+}
+
+typealias HeadLineNewsPresentable = NewsPresentable & NewsDescriptionPresentable & Focusable
+
+struct HeadLineNewsViewModel: HeadLineNewsPresentable {
+  //MARK: - Properties
+  let title: String
+  let press: String
+  var date: String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy.MM.dd"
+    return formatter.string(from: createdDate)
+  }
+  let body: String
+  let imageURL: URL?
+  var isFocused: Bool
+  private let createdDate: Date
+  
+  init(title: String, press: String, body: String, imageURL: URL?, isFocused: Bool, createdDate: Date) {
+    self.title = title
+    self.press = press
+    self.body = body
+    self.imageURL = imageURL
+    self.isFocused = isFocused
+    self.createdDate = createdDate
+  }
+}

--- a/NewsFit/NewsFit/View/NewsFitHomeViewController.swift
+++ b/NewsFit/NewsFit/View/NewsFitHomeViewController.swift
@@ -175,7 +175,6 @@ private extension NewsFitHomeViewController {
       press: "한겨레",
       body: "부상자 361명, 15만5천명 대피",
       imageURL: nil,
-      isFocused: true,
       createdDate: .now
     ),
     HeadLineNewsViewModel(
@@ -183,7 +182,6 @@ private extension NewsFitHomeViewController {
       press: "조선일보",
       body: "두두두",
       imageURL: nil,
-      isFocused: true,
       createdDate: .now
     ),
     HeadLineNewsViewModel(
@@ -191,7 +189,6 @@ private extension NewsFitHomeViewController {
       press: "동아일보",
       body: "전문가들, 해안지역 대규모 이주 필요성 경고",
       imageURL: nil,
-      isFocused: false,
       createdDate: .now
     ),
     HeadLineNewsViewModel(
@@ -199,7 +196,6 @@ private extension NewsFitHomeViewController {
       press: "중앙일보",
       body: "전문가들, 기술 발전에 따른 윤리적 문제 논의 시작",
       imageURL: nil,
-      isFocused: true,
       createdDate: .now
     ),
     HeadLineNewsViewModel(
@@ -207,7 +203,6 @@ private extension NewsFitHomeViewController {
       press: "한겨레",
       body: "2026년부터 본격적인 탐사 임무 시작 예정",
       imageURL: nil,
-      isFocused: false,
       createdDate: .now
     ),
     HeadLineNewsViewModel(
@@ -215,7 +210,6 @@ private extension NewsFitHomeViewController {
       press: "연합뉴스",
       body: "각국 중앙은행, 금리 인하 및 경제 지원책 발표",
       imageURL: nil,
-      isFocused: true,
       createdDate: .now
     )
   ]}

--- a/NewsFit/NewsFit/View/NewsFitHomeViewController.swift
+++ b/NewsFit/NewsFit/View/NewsFitHomeViewController.swift
@@ -95,7 +95,11 @@ final class NewsFitHomeViewController: UIViewController {
 //MARK: - UICollectionViewDataSource
 extension NewsFitHomeViewController: UICollectionViewDataSource {
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return 10
+    if section == 1 {
+      return dummyHeadLineViewModel.count
+    } else {
+      return 10
+    }
   }
   func numberOfSections(in collectionView: UICollectionView) -> Int {
     return 3
@@ -110,7 +114,7 @@ extension NewsFitHomeViewController: UICollectionViewDataSource {
     } else if indexPath.section == 1 {
       let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constant.headLineCellReuseID, for: indexPath)
       cell.contentConfiguration = UIHostingConfiguration {
-        HeadLineNewsCell()
+        HeadLineNewsCell(viewModel: dummyHeadLineViewModel[indexPath.row])
       }.margins(.all, 0)
       return cell
     } else {
@@ -162,4 +166,57 @@ final class NewsFitHomeSectionHeaderView: UICollectionReusableView {
       make.verticalEdges.equalToSuperview()
     }
   }
+}
+
+private extension NewsFitHomeViewController {
+  var dummyHeadLineViewModel: [HeadLineNewsViewModel] {[
+    HeadLineNewsViewModel(
+      title: "\"최악의 기후재앙\"...브라질 남부 폭우에 사망.실종 220명 넘어서",
+      press: "한겨레",
+      body: "부상자 361명, 15만5천명 대피",
+      imageURL: nil,
+      isFocused: true,
+      createdDate: .now
+    ),
+    HeadLineNewsViewModel(
+      title: "고양딱지",
+      press: "조선일보",
+      body: "두두두",
+      imageURL: nil,
+      isFocused: true,
+      createdDate: .now
+    ),
+    HeadLineNewsViewModel(
+      title: "\"지구온난화, 해수면 상승 가속\"...미국 동부 연안 위험 수준 도달",
+      press: "동아일보",
+      body: "전문가들, 해안지역 대규모 이주 필요성 경고",
+      imageURL: nil,
+      isFocused: false,
+      createdDate: .now
+    ),
+    HeadLineNewsViewModel(
+      title: "인공지능, 미래 사회를 어떻게 변화시킬까?",
+      press: "중앙일보",
+      body: "전문가들, 기술 발전에 따른 윤리적 문제 논의 시작",
+      imageURL: nil,
+      isFocused: true,
+      createdDate: .now
+    ),
+    HeadLineNewsViewModel(
+      title: "\"우주 탐사의 새 시대\"...NASA, 유인 화성 탐사 계획 발표",
+      press: "한겨레",
+      body: "2026년부터 본격적인 탐사 임무 시작 예정",
+      imageURL: nil,
+      isFocused: false,
+      createdDate: .now
+    ),
+    HeadLineNewsViewModel(
+      title: "세계 경제 위기...각국 정부 대응 방안 모색",
+      press: "연합뉴스",
+      body: "각국 중앙은행, 금리 인하 및 경제 지원책 발표",
+      imageURL: nil,
+      isFocused: true,
+      createdDate: .now
+    )
+  ]}
 }


### PR DESCRIPTION
## 변경사항
- [x] 뉴스 표현 프로토콜
- [x] 뉴스사 이미지 표현 프로토콜
- [x] 헤드라인 뷰모델
- [x] 뷰모델과 셀 연결

## 테스트 방법
실행하면 됩니다!

## 리뷰 노트
일단 뉴스 뷰모델을 기반으로 만들고자 했다.

뉴스는 기본적으로 

- 제목
- 언론사
- 날짜(시간)
- 뉴스이미지

이 4가지를 표현해야한다.

또한 일부 항목은 언론사 사진을 가질 수 있다.

- 언론사 사진

어떤 항목은 짧은 설명을 가질 수 있다.

- 뉴스 설명

