### PR TITLE
[FEAT] 검색결과 뷰 구현

### DIFF
--- a/NewsFit/NewsFit/View/NewsSearch/NewsFitSearchView.swift
+++ b/NewsFit/NewsFit/View/NewsSearch/NewsFitSearchView.swift
@@ -1,74 +1,34 @@
 import SwiftUI
 
 struct NewsFitSearchView: View {
-  @State private var text = ""
+  @State private var text: String = ""
+  private var isSearchMode: Bool {
+    !text.isEmpty
+  }
   var body: some View {
     VStack(spacing: 0) {
-      searchBar()
-      recentlySearched()
+      NewsSearchBar(text: $text)
+      RecentlySearchedView()
       Divider()
-      ScrollView {
-        VStack(alignment: .leading, spacing: 20) {
-          ForEach(0..<10) { index in
-            CategorizedNewsView()
-              .frame(height: 200)
-              .padding(.horizontal)
-          }
+      if isSearchMode {
+        NewsSearchResultView()
+      } else {
+        categorizedNewsView()
+      }
+    }
+  }
+  @ViewBuilder
+  private func categorizedNewsView() -> some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 20) {
+        ForEach(0..<10) { index in
+          CategorizedNewsView()
+            .frame(height: 200)
+            .padding(.horizontal)
         }
       }
       .padding(.top)
     }
-  }
-  
-  @ViewBuilder
-  private func searchBar() -> some View {
-    HStack {
-      TextField("키워드 / 언론사 / 카테고리로 검색", text: $text)
-      Image(.nfSearchButton)
-    }
-    .padding(.horizontal)
-    .padding(.vertical, 10)
-    .modifier(NFBorderModifier())
-    .padding(.horizontal)
-  }
-  @ViewBuilder
-  private func recentlySearched() -> some View {
-    VStack {
-      HStack {
-        Text("최근검색어")
-          .font(.headline)
-        Spacer()
-        Button(action: {}) {
-          Text("모두 지우기")
-            .font(.subheadline)
-            .foregroundColor(.secondary)
-        }
-      }.padding(.bottom, 10)
-      ScrollView(.horizontal) {
-        HStack {
-          ForEach(0..<10) { index in
-            RecentlySerchedCell()
-          }
-        }
-      }
-      .scrollIndicators(.never)
-    }
-    .padding()
-  }
-}
-
-fileprivate struct RecentlySerchedCell: View {
-  var body: some View {
-    HStack(alignment: .center) {
-      Text("사라져버려")
-      Spacer()
-      Button(action: {}) {
-        Image(.nfxButton)
-      }
-    }
-    .padding(8)
-    .modifier(NFBorderModifier())
-    .padding(1)
   }
 }
 

--- a/NewsFit/NewsFit/View/NewsSearch/NewsSearchBar.swift
+++ b/NewsFit/NewsFit/View/NewsSearch/NewsSearchBar.swift
@@ -1,0 +1,24 @@
+//
+//  SearchBar.swift
+//  NewsFit
+//
+//  Created by user on 10/23/24.
+//
+
+import SwiftUI
+
+struct NewsSearchBar: View {
+  @Binding var text: String
+  var body: some View {
+    HStack {
+      TextField("키워드 / 언론사 / 카테고리로 검색", text: $text)
+      Image(.nfSearchButton)
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 10)
+    .modifier(NFBorderModifier())
+    .padding(.horizontal)
+  }
+}
+
+

--- a/NewsFit/NewsFit/View/NewsSearch/NewsSearchResultView.swift
+++ b/NewsFit/NewsFit/View/NewsSearch/NewsSearchResultView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct NewsSearchResultView: View {
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading) {
+        Text("\"검색어\"에 대한 뉴스")
+          .font(.title.bold())
+          .padding(.leading)
+        VStack {
+          ForEach(0..<10) { index in
+            VStack(alignment: .leading) {
+              NewsCell(viewModel: NewsViewModel(news: .init(id: 10, title: "hisdfsdfsdfdsfsffssdfsdfdsfsddfsdfdfsdfdsfsdfdsdfdsfsdfdsfsdfsddsf", content: "cc", createdAt: .now, press: "고양이뉴스!", category: "IT", comments: [])))
+                .padding()
+              Divider()
+            }
+          }
+        }
+        .padding()
+        .background(Color.nfBackgroundAccent.opacity(0.3))
+        .modifier(NFBorderModifier())
+      }
+      .padding(.top)
+      .padding(.bottom, 110)
+    }
+  }
+}
+
+
+#Preview {
+  NewsSearchResultView()
+}

--- a/NewsFit/NewsFit/View/NewsSearch/RecentlySearchedView.swift
+++ b/NewsFit/NewsFit/View/NewsSearch/RecentlySearchedView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct RecentlySearchedView: View {
+  var body: some View {
+    VStack {
+      HStack {
+        Text("최근검색어")
+          .font(.headline)
+        Spacer()
+        Button(action: {}) {
+          Text("모두 지우기")
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+        }
+      }.padding(.bottom, 10)
+      ScrollView(.horizontal) {
+        HStack {
+          ForEach(0..<10) { index in
+            RecentlySerchedCell()
+          }
+        }
+      }
+      .scrollIndicators(.never)
+    }
+    .padding()
+  }
+}
+
+
+fileprivate struct RecentlySerchedCell: View {
+  var body: some View {
+    HStack(alignment: .center) {
+      Text("사라져버려")
+      Spacer()
+      Button(action: {}) {
+        Image(.nfxButton)
+      }
+    }
+    .padding(8)
+    .modifier(NFBorderModifier())
+    .padding(1)
+  }
+}


### PR DESCRIPTION
## 변경사항
- [x] 검색바 분리
- [x] 최근검색어 분리
- [x] 검색 결과 구현

## 테스트 방법
빌드해서 프리뷰로만 확인 가능

## 노트
하... 이게 말야... 흠 ... 검색을 할 때마다 새로운 뷰를 만드는 것 같아서 별로여서
Navigation쓰고 싶은데 이놈의 SwiftUI는 왤케 불편하냐!!!!
으아아아앙아아아앙아아아아앙!!!!!

## 스크린샷

<img width="315" alt="image" src="https://github.com/user-attachments/assets/e442b147-cce1-4464-b4d4-6f41056fbfb5">
